### PR TITLE
iOS 12 の UDID をサポート

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -186,7 +186,7 @@ func connectedDevices() []Device {
 		fmt.Println("Command Exec Error:", err)
 	}
 
-	r := regexp.MustCompile(`(..*)\s\((..*)\)\s\[(\w+)\]`)
+	r := regexp.MustCompile(`(..*)\s\((..*)\)\s\[([\w|-]+)\]`)
 	devices := make([]Device, 0)
 
 	for _, x := range strings.Split(string(out), "\n") {


### PR DESCRIPTION
概要
----

下記のコマンド実行例に示すように、iOS 12 以降で UDID の文字列表現が変更になったため、どちらにも対応できるようにソースコード中の正規表現を変更します。

```zsh
% instruments -s
Known Devices:
iPhone XS Max (018) (12.0) [****8020-************002E]
iPad (101) (10.3.3) [********************************e586a108]
...
```

Thanks: @mactkg